### PR TITLE
Added getter for thumbnailphoto

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -668,4 +668,9 @@ class User extends Entry
 
         return $result;
     }
+    
+    public function getThumbnail()
+    {
+        return $this->getAttribute(ActiveDirectory::THUMBNAIL, 0);
+    }
 }


### PR DESCRIPTION
Retrieves thumbnailphoto attribute from AD and returns a string which can be displayed as image via the following ;
`$imagestring ='';  //returned string`
`$tempFile = tempnam(sys_get_temp_dir(), 'image');`
`file_put_contents($tempFile, $imageString);`
`$finfo = new finfo(FILEINFO_MIME_TYPE);`
`$mime  = explode(';', $finfo->file($tempFile));`
`echo '<img src="data:' . $mime[0] . ';base64,' . base64_encode($imageString) . '"/>';`
